### PR TITLE
remove leftover usage of "six" Python 2+3 compatibility layer

### DIFF
--- a/package/debian10/control
+++ b/package/debian10/control
@@ -47,7 +47,6 @@ Depends: ${misc:Depends},
          python3-numpy,
          python3-matplotlib,
          python3-scipy,
-         python3-six,
          python3-pyfai
 # Recommends:
 # Suggests: python3-rfoo

--- a/package/debian11/control
+++ b/package/debian11/control
@@ -47,7 +47,6 @@ Depends: ${misc:Depends},
          python3-numpy,
          python3-matplotlib,
          python3-scipy,
-         python3-six,
          python3-pyfai
 # Recommends:
 # Suggests: python3-rfoo

--- a/package/debian12/control
+++ b/package/debian12/control
@@ -49,7 +49,6 @@ Depends: ${misc:Depends},
          python3-numpy,
          python3-matplotlib,
          python3-scipy,
-         python3-six,
          python3-pyfai
 # Recommends:
 # Suggests: python3-rfoo

--- a/package/debian9/control
+++ b/package/debian9/control
@@ -72,7 +72,6 @@ Depends: ${misc:Depends},
          python3-numpy,
          python3-matplotlib,
          python3-scipy,
-         python3-six,
 # Recommends:
 # Suggests: python3-rfoo
 Description: Free tools for small angle scattering analysis - Python3

--- a/src/freesas/cormap.py
+++ b/src/freesas/cormap.py
@@ -9,7 +9,7 @@ from .containers import GOF
 from ._cormap import measure_longest
 
 
-class LongestRunOfHeads(object):
+class LongestRunOfHeads:
     """Implements the "longest run of heads" by Mark F. Schilling
     The College Mathematics Journal, Vol. 21, No. 3, (1990), pp. 196-207
     http://www.silx.org/pub/freesas/CorMap_math.pdf

--- a/src/freesas/model.py
+++ b/src/freesas/model.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 # coding: utf-8
-from __future__ import print_function
 
 __author__ = "Guillaume"
 __license__ = "MIT"
@@ -9,7 +8,6 @@ __copyright__ = "2015, ESRF"
 import os
 from math import sqrt
 import threading
-import six
 import numpy
 try:
     from . import _distance
@@ -42,7 +40,7 @@ class SASModel:
         """
         :param molecule: if str, name of a pdb file, else if 2d-array, coordinates of atoms of a molecule
         """
-        if isinstance(molecule, (six.text_type, six.binary_type)) and os.path.exists(molecule):
+        if isinstance(molecule, (str, bytes)) and os.path.exists(molecule):
             self.read(molecule)
         else:
             self.atoms = molecule if molecule is not None else []  # initial coordinates of each dummy atoms of the molecule, fourth column full of one for the transformation matrix

--- a/src/freesas/test/test_align.py
+++ b/src/freesas/test/test_align.py
@@ -1,5 +1,4 @@
 #!/usr/bin/python
-from __future__ import print_function
 
 __author__ = "Guillaume"
 __license__ = "MIT"

--- a/src/freesas/test/test_all.py
+++ b/src/freesas/test/test_all.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 # coding: utf-8
-from __future__ import print_function
 
 __author__ = "Guillaume"
 __license__ = "MIT"

--- a/src/freesas/test/test_average.py
+++ b/src/freesas/test/test_average.py
@@ -1,6 +1,5 @@
 #!/usr/bin/python
 # coding: utf-8
-from __future__ import print_function
 
 __author__ = "Guillaume"
 __license__ = "MIT"

--- a/src/freesas/test/test_cormap.py
+++ b/src/freesas/test/test_cormap.py
@@ -1,6 +1,5 @@
 #!/usr/bin/python
 # coding: utf-8
-from __future__ import print_function
 
 __author__ = "Jerome"
 __license__ = "MIT"

--- a/src/freesas/test/test_distance.py
+++ b/src/freesas/test/test_distance.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
-from __future__ import print_function
 
 __author__ = "Jérôme Kieffer"
 __license__ = "MIT"

--- a/src/freesas/test/test_model.py
+++ b/src/freesas/test/test_model.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
 # coding: utf-8
-from __future__ import print_function
 
 __author__ = "Guillaume"
 __license__ = "MIT"

--- a/src/freesas/test/utilstest.py
+++ b/src/freesas/test/utilstest.py
@@ -27,7 +27,7 @@ def get_datafile(name):
 def clean():
     pass
 
-class TestOptions(object):
+class TestOptions:
     """
     Class providing useful stuff for preparing tests.
     """

--- a/src/freesas/transformations.py
+++ b/src/freesas/transformations.py
@@ -193,8 +193,6 @@ True
 
 """
 
-from __future__ import division, print_function
-
 import math
 
 import numpy
@@ -1503,7 +1501,7 @@ def random_rotation_matrix(rand=None):
     return quaternion_matrix(random_quaternion(rand))
 
 
-class Arcball(object):
+class Arcball:
     """Virtual Trackball Control.
 
     >>> ball = Arcball()


### PR DESCRIPTION
I noticed this stray usage in the latest update for Debian